### PR TITLE
Implement OpenAI realtime transcription fallback

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -31,7 +31,8 @@
       "Bash(/Users/lukasz/.nvm/versions/node/v18.20.4/lib/node_modules/@anthropic-ai/claude-code/vendor/ripgrep/arm64-darwin/rg \"e2eeOnJoin\" --type tsx)",
       "Bash(/Users/lukasz/.nvm/versions/node/v18.20.4/lib/node_modules/@anthropic-ai/claude-code/vendor/ripgrep/arm64-darwin/rg \"e2eeOnJoin\" app/)",
       "Bash(/Users/lukasz/.nvm/versions/node/v18.20.4/lib/node_modules/@anthropic-ai/claude-code/vendor/ripgrep/arm64-darwin/rg \"e2eeOnJoin\\(\" app/)",
-      "Bash(/Users/lukasz/.nvm/versions/node/v18.20.4/lib/node_modules/@anthropic-ai/claude-code/vendor/ripgrep/arm64-darwin/rg \"\\.e2eeOnJoin\" app/)"
+      "Bash(/Users/lukasz/.nvm/versions/node/v18.20.4/lib/node_modules/@anthropic-ai/claude-code/vendor/ripgrep/arm64-darwin/rg \"\\.e2eeOnJoin\" app/)",
+      "Bash(git checkout:*)"
     ],
     "deny": []
   }

--- a/app/components/TranscriptionService.tsx
+++ b/app/components/TranscriptionService.tsx
@@ -1,18 +1,24 @@
-import { useEffect } from "react";
+import React, { useEffect, useRef, useCallback } from 'react';
 
-type Transcription = {
+// Types for transcription
+export type Transcription = {
   id: string;
   text: string;
   timestamp: number;
   isFinal: boolean;
-  userId?: string;
-  speaker?: string;
+  speaker: string;
 };
+
+// Configuration
+const REALTIME_API_URL = 'wss://api.openai.com/v1/realtime';
+const CHUNK_DURATION_MS = 5000; // 5 seconds for POST API chunks
+const MIN_AUDIO_LEVEL = 0.01; // Minimum RMS level to consider as speech
+const RECONNECT_DELAY_MS = 2000; // Delay before attempting reconnection
 
 // Helper function to convert AudioBuffer to WAV format
 function audioBufferToWav(buffer: AudioBuffer): ArrayBuffer {
   const length = buffer.length;
-  const numberOfChannels = buffer.numberOfChannels;
+  const numberOfChannels = 1; // Force mono for transcription
   const sampleRate = buffer.sampleRate;
   const bitsPerSample = 16;
   const bytesPerSample = bitsPerSample / 8;
@@ -46,18 +52,36 @@ function audioBufferToWav(buffer: AudioBuffer): ArrayBuffer {
   writeString(36, 'data');
   view.setUint32(40, dataSize, true);
 
-  // Convert float samples to 16-bit PCM
+  // Convert float samples to 16-bit PCM (mono)
   let offset = headerSize;
+  const channelData = buffer.getChannelData(0); // Use first channel only
   for (let i = 0; i < length; i++) {
-    for (let channel = 0; channel < numberOfChannels; channel++) {
-      const sample = Math.max(-1, Math.min(1, buffer.getChannelData(channel)[i]));
-      const intSample = sample < 0 ? sample * 0x8000 : sample * 0x7FFF;
-      view.setInt16(offset, intSample, true);
-      offset += 2;
-    }
+    const sample = Math.max(-1, Math.min(1, channelData[i]));
+    const intSample = sample < 0 ? sample * 0x8000 : sample * 0x7FFF;
+    view.setInt16(offset, intSample, true);
+    offset += 2;
   }
 
   return arrayBuffer;
+}
+
+// Convert PCM16 audio to base64 for real-time API
+function pcm16ToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+// Calculate RMS (Root Mean Square) for volume detection
+function calculateRMS(audioData: Float32Array): number {
+  let sum = 0;
+  for (let i = 0; i < audioData.length; i++) {
+    sum += audioData[i] * audioData[i];
+  }
+  return Math.sqrt(sum / audioData.length);
 }
 
 type Props = {
@@ -73,19 +97,223 @@ export const TranscriptionService: React.FC<Props> = ({
   isActive,
   participants,
 }) => {
+  const realtimeWsRef = useRef<WebSocket | null>(null);
+  const fallbackModeRef = useRef<boolean>(false);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const processorRef = useRef<ScriptProcessorNode | null>(null);
+  const tokenRef = useRef<string>('');
+  const isConnectingRef = useRef<boolean>(false);
+  const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Generate prompt with participant names
+  const generatePrompt = useCallback(() => {
+    return `This is a transcription of an online meeting with participants: ${participants.join(', ')}. Please transcribe the conversation accurately, including speaker identification when possible.`;
+  }, [participants]);
+
+  // Setup real-time WebSocket connection
+  const setupRealtimeConnection = useCallback(async (token: string) => {
+    if (isConnectingRef.current || realtimeWsRef.current?.readyState === WebSocket.OPEN) {
+      return;
+    }
+
+    isConnectingRef.current = true;
+    
+    try {
+      console.log('Attempting to connect to OpenAI Realtime API...');
+      
+      const ws = new WebSocket(`${REALTIME_API_URL}?intent=transcription&authorization=${token}`);
+      
+      ws.addEventListener('open', () => {
+        console.log('Connected to OpenAI Realtime API');
+        isConnectingRef.current = false;
+        fallbackModeRef.current = false;
+        
+        // Configure transcription session
+        ws.send(JSON.stringify({
+          type: 'transcription_session.update',
+          input_audio_format: 'pcm16',
+          input_audio_transcription: {
+            model: 'gpt-4o-transcribe',
+            prompt: generatePrompt(),
+            language: 'en',
+          },
+          turn_detection: {
+            type: 'server_vad',
+            threshold: 0.5,
+            prefix_padding_ms: 300,
+            silence_duration_ms: 500,
+          },
+        }));
+      });
+
+      ws.addEventListener('message', (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          
+          if (data.type === 'input_audio_transcription.completed') {
+            const transcript = data.transcript;
+            if (transcript && transcript.trim()) {
+              onTranscription({
+                id: `realtime_${Date.now()}_${Math.random()}`,
+                text: transcript,
+                timestamp: Date.now(),
+                isFinal: true,
+                speaker: 'OpenAI Realtime',
+              });
+            }
+          } else if (data.type === 'error') {
+            console.error('Realtime API error:', data.error);
+            // If we get an error, switch to fallback mode
+            fallbackModeRef.current = true;
+            ws.close();
+          }
+        } catch (e) {
+          console.error('Error parsing realtime message:', e);
+        }
+      });
+
+      ws.addEventListener('error', (error) => {
+        console.error('Realtime WebSocket error:', error);
+        isConnectingRef.current = false;
+        fallbackModeRef.current = true;
+      });
+
+      ws.addEventListener('close', () => {
+        console.log('Realtime WebSocket closed');
+        isConnectingRef.current = false;
+        realtimeWsRef.current = null;
+        
+        // If not in fallback mode, try to reconnect
+        if (!fallbackModeRef.current) {
+          reconnectTimeoutRef.current = setTimeout(() => {
+            setupRealtimeConnection(token);
+          }, RECONNECT_DELAY_MS);
+        }
+      });
+
+      realtimeWsRef.current = ws;
+    } catch (error) {
+      console.error('Failed to setup realtime connection:', error);
+      isConnectingRef.current = false;
+      fallbackModeRef.current = true;
+    }
+  }, [generatePrompt, onTranscription]);
+
+  // Send audio chunk via POST API (fallback)
+  const sendAudioChunkViaPost = useCallback(async (audioBlob: Blob, token: string) => {
+    try {
+      const formData = new FormData();
+      formData.append('file', audioBlob, 'audio.wav');
+      formData.append('model', 'gpt-4o-transcribe');
+      formData.append('language', 'en');
+      formData.append('response_format', 'json');
+      formData.append('prompt', generatePrompt());
+
+      const response = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+        method: 'POST',
+        headers: { 
+          'Authorization': `Bearer ${token}`,
+        },
+        body: formData,
+      });
+
+      if (response.ok) {
+        const data = await response.json() as { text?: string };
+        if (data.text && data.text.trim()) {
+          onTranscription({
+            id: `post_${Date.now()}_${Math.random()}`,
+            text: data.text,
+            timestamp: Date.now(),
+            isFinal: true,
+            speaker: 'OpenAI',
+          });
+        }
+      } else {
+        console.error('POST transcription failed:', response.status);
+      }
+    } catch (error) {
+      console.error('Error sending audio chunk via POST:', error);
+    }
+  }, [generatePrompt, onTranscription]);
+
+  // Setup audio processing
+  const setupAudioProcessing = useCallback((stream: MediaStream, token: string) => {
+    // Clean up existing audio context
+    if (audioContextRef.current) {
+      audioContextRef.current.close();
+    }
+
+    const audioContext = new (window.AudioContext || (window as any).webkitAudioContext)();
+    audioContextRef.current = audioContext;
+    
+    const source = audioContext.createMediaStreamSource(stream);
+    const processor = audioContext.createScriptProcessor(4096, 1, 1);
+    processorRef.current = processor;
+
+    let audioBuffer: Float32Array[] = [];
+    let lastSendTime = Date.now();
+
+    processor.onaudioprocess = (e) => {
+      const inputData = e.inputBuffer.getChannelData(0);
+      audioBuffer.push(new Float32Array(inputData));
+
+      const currentTime = Date.now();
+      const shouldSendChunk = currentTime - lastSendTime >= CHUNK_DURATION_MS;
+
+      if (shouldSendChunk && audioBuffer.length > 0) {
+        // Combine audio buffers
+        const totalLength = audioBuffer.reduce((acc, buf) => acc + buf.length, 0);
+        const combinedBuffer = new Float32Array(totalLength);
+        let offset = 0;
+        for (const buf of audioBuffer) {
+          combinedBuffer.set(buf, offset);
+          offset += buf.length;
+        }
+
+        // Calculate RMS to check if there's actual audio
+        const rms = calculateRMS(combinedBuffer);
+        
+        if (rms > MIN_AUDIO_LEVEL) {
+          // Create audio buffer for conversion
+          const audioBufferObj = audioContext.createBuffer(1, combinedBuffer.length, audioContext.sampleRate);
+          audioBufferObj.copyToChannel(combinedBuffer, 0);
+
+          if (!fallbackModeRef.current && realtimeWsRef.current?.readyState === WebSocket.OPEN) {
+            // Send via real-time API
+            const wavBuffer = audioBufferToWav(audioBufferObj);
+            // Extract PCM data (skip WAV header)
+            const pcmData = new Uint8Array(wavBuffer, 44);
+            const base64Audio = pcm16ToBase64(pcmData.buffer);
+            
+            realtimeWsRef.current.send(JSON.stringify({
+              type: 'input_audio_buffer.append',
+              audio: base64Audio,
+            }));
+          } else {
+            // Use POST API fallback
+            const wavBuffer = audioBufferToWav(audioBufferObj);
+            const audioBlob = new Blob([wavBuffer], { type: 'audio/wav' });
+            sendAudioChunkViaPost(audioBlob, token);
+          }
+        }
+
+        // Reset buffer and timer
+        audioBuffer = [];
+        lastSendTime = currentTime;
+      }
+    };
+
+    source.connect(processor);
+    processor.connect(audioContext.destination);
+  }, [sendAudioChunkViaPost]);
 
   useEffect(() => {
     if (!isActive || audioTracks.length === 0) return;
 
     console.log('Starting OpenAI transcription service');
     
-    // Use the first audio track (user's microphone)
-    const primaryAudioTrack = audioTracks[0];
-    const combinedStream = new MediaStream([primaryAudioTrack]);
-
-    let mediaRecorder: MediaRecorder;
-    let isRecording = false;
-    let recordingInterval: NodeJS.Timeout;
+    let mediaRecorder: MediaRecorder | null = null;
+    let isCleanedUp = false;
 
     (async () => {
       try {
@@ -95,191 +323,107 @@ export const TranscriptionService: React.FC<Props> = ({
           throw new Error(`Failed to get OpenAI token: ${resp.status}`);
         }
         const { token }: { token: string } = await resp.json();
+        tokenRef.current = token;
 
-        // Attempt realtime WebSocket connection
-        const prompt = `This is transcription of an online meeting with participants: ${participants.join(', ')}.`;
-        let ws: WebSocket | null = null;
-        let useRealtime = true;
-        try {
-          ws = new WebSocket(
-            `wss://api.openai.com/v1/realtime?intent=transcription&access_token=${token}`
-          );
+        if (isCleanedUp) return;
 
-          ws.addEventListener('open', () => {
-            ws?.send(
-              JSON.stringify({
-                type: 'transcription_session.update',
-                input_audio_format: 'pcm16',
-                input_audio_transcription: {
-                  model: 'gpt-4o-transcribe',
-                  prompt,
-                  language: 'en',
-                },
-              })
-            );
+        // Try to establish real-time connection first
+        await setupRealtimeConnection(token);
+
+        // Setup audio processing
+        const primaryAudioTrack = audioTracks[0];
+        const combinedStream = new MediaStream([primaryAudioTrack]);
+        setupAudioProcessing(combinedStream, token);
+
+        // Alternative: Use MediaRecorder for chunked recording (backup method)
+        if (fallbackModeRef.current) {
+          mediaRecorder = new MediaRecorder(combinedStream, {
+            mimeType: 'audio/webm;codecs=opus'
           });
 
-          ws.addEventListener('message', (event) => {
-            try {
-              const data = JSON.parse(event.data);
-              if (data.text) {
-                onTranscription({
-                  id: `openai_${Date.now()}_${Math.random()}`,
-                  text: data.text,
-                  timestamp: Date.now(),
-                  isFinal: true,
-                  speaker: 'OpenAI',
-                });
-              }
-            } catch (e) {
-              console.error('Realtime transcription parse error', e);
+          const audioChunks: Blob[] = [];
+
+          mediaRecorder.ondataavailable = (event) => {
+            if (event.data.size > 0) {
+              audioChunks.push(event.data);
             }
-          });
+          };
 
-          ws.addEventListener('error', () => {
-            console.warn('Realtime WebSocket failed, falling back to POST');
-            useRealtime = false;
-          });
-        } catch (err) {
-          console.warn('Realtime WebSocket setup failed, falling back to POST');
-          useRealtime = false;
-        }
-
-        // Create MediaRecorder
-        mediaRecorder = new MediaRecorder(combinedStream, {
-          mimeType: 'audio/webm;codecs=opus',
-        });
-
-        const audioChunks: Blob[] = [];
-
-        mediaRecorder.ondataavailable = (event) => {
-          if (event.data.size > 100) {
-            audioChunks.push(event.data);
-          }
-        };
-
-        mediaRecorder.onstop = async () => {
-          if (audioChunks.length === 0) {
-            restartRecording();
-            return;
-          }
-
-          try {
-            // Create audio blob
-            const recordedBlob = new Blob(audioChunks, { type: 'audio/webm;codecs=opus' });
-            audioChunks.length = 0;
-
-            // Skip tiny audio files (likely silence)
-            if (recordedBlob.size < 5000) {
-              restartRecording();
-              return;
-            }
-
-            // Convert to WAV and check for silence
-            const conversionAudioContext = new AudioContext();
-            const arrayBuffer = await recordedBlob.arrayBuffer();
-            const audioBuffer = await conversionAudioContext.decodeAudioData(arrayBuffer);
+          mediaRecorder.onstop = async () => {
+            if (audioChunks.length === 0 || isCleanedUp) return;
             
-            // Check for silence using RMS
-            const channelData = audioBuffer.getChannelData(0);
-            const rms = Math.sqrt(channelData.reduce((sum, sample) => sum + sample * sample, 0) / channelData.length);
+            // Process and send the recorded chunk
+            const audioBlob = new Blob(audioChunks, { type: 'audio/webm' });
             
-            // Skip if too quiet (silence)
-            if (rms < 0.01) {
-              console.log('Skipping silent audio, RMS:', rms.toFixed(4));
-              await conversionAudioContext.close();
-              restartRecording();
-              return;
-            }
-            
-            // Convert to WAV
+            // Convert WebM to WAV for OpenAI API
+            const arrayBuffer = await audioBlob.arrayBuffer();
+            const audioContext = new (window.AudioContext || (window as any).webkitAudioContext)();
+            const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
             const wavBuffer = audioBufferToWav(audioBuffer);
-            await conversionAudioContext.close();
+            const wavBlob = new Blob([wavBuffer], { type: 'audio/wav' });
+            
+            await sendAudioChunkViaPost(wavBlob, token);
+            audioContext.close();
+          };
 
-            if (useRealtime && ws && ws.readyState === WebSocket.OPEN) {
-              // send via realtime websocket
-              const base64 = btoa(String.fromCharCode(...new Uint8Array(wavBuffer)));
-              ws.send(
-                JSON.stringify({
-                  type: 'input_audio_buffer.append',
-                  audio: base64,
-                })
-              );
-            } else {
-              const audioBlob = new Blob([wavBuffer], { type: 'audio/wav' });
-              console.log('Sending audio to OpenAI via POST:', audioBlob.size, 'bytes, RMS:', rms.toFixed(4));
-              const formData = new FormData();
-              formData.append('file', audioBlob, 'audio.wav');
-              formData.append('model', 'gpt-4o-transcribe');
-              formData.append('language', 'en');
-              formData.append('response_format', 'json');
-              formData.append('prompt', prompt);
-
-              const transcriptionResp = await fetch('https://api.openai.com/v1/audio/transcriptions', {
-                method: 'POST',
-                headers: { Authorization: `Bearer ${token}` },
-                body: formData,
-              });
-
-              if (transcriptionResp.ok) {
-                const transcriptionData = (await transcriptionResp.json()) as { text?: string };
-                if (transcriptionData.text && transcriptionData.text.trim()) {
-                  onTranscription({
-                    id: `openai_${Date.now()}_${Math.random()}`,
-                    text: transcriptionData.text,
-                    timestamp: Date.now(),
-                    isFinal: true,
-                    speaker: 'OpenAI',
-                  });
+          // Start recording in chunks
+          const recordingInterval = setInterval(() => {
+            if (mediaRecorder?.state === 'recording') {
+              mediaRecorder.stop();
+              audioChunks.length = 0;
+              setTimeout(() => {
+                if (!isCleanedUp && mediaRecorder?.state === 'inactive') {
+                  mediaRecorder.start();
                 }
-              } else {
-                console.error('OpenAI transcription failed:', transcriptionResp.status);
-              }
+              }, 100);
             }
-          } catch (error) {
-            console.error('Transcription error:', error);
-          }
+          }, CHUNK_DURATION_MS);
 
-          restartRecording();
-        };
-
-        const restartRecording = () => {
-          if (isRecording && mediaRecorder.state === 'inactive') {
-            try {
-              mediaRecorder.start(1000); // Request data every 1s
-            } catch (error) {
-              console.error('Error restarting MediaRecorder:', error);
-            }
-          }
-        };
-
-        // Start recording
-        isRecording = true;
-        mediaRecorder.start(1000);
-        
-        // Set up interval to create 8-second audio chunks
-        recordingInterval = setInterval(() => {
-          if (mediaRecorder.state === 'recording') {
-            mediaRecorder.stop();
-          }
-        }, 8000);
-
+          mediaRecorder.start();
+          
+          return () => {
+            clearInterval(recordingInterval);
+          };
+        }
       } catch (error) {
-        console.error('Error setting up OpenAI transcription:', error);
+        console.error('TranscriptionService error:', error);
       }
     })();
 
-    // Cleanup
+    // Cleanup function
     return () => {
-      isRecording = false;
-      if (recordingInterval) {
-        clearInterval(recordingInterval);
+      isCleanedUp = true;
+      
+      // Close WebSocket
+      if (realtimeWsRef.current) {
+        realtimeWsRef.current.close();
+        realtimeWsRef.current = null;
       }
-      if (mediaRecorder && mediaRecorder.state === 'recording') {
+
+      // Clear reconnect timeout
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
+      }
+
+      // Stop MediaRecorder
+      if (mediaRecorder && mediaRecorder.state !== 'inactive') {
         mediaRecorder.stop();
       }
+
+      // Close audio context
+      if (audioContextRef.current) {
+        audioContextRef.current.close();
+        audioContextRef.current = null;
+      }
+
+      // Disconnect processor
+      if (processorRef.current) {
+        processorRef.current.disconnect();
+        processorRef.current = null;
+      }
     };
-  }, [isActive, audioTracks, onTranscription, participants]);
+  }, [isActive, audioTracks, participants, setupRealtimeConnection, setupAudioProcessing, sendAudioChunkViaPost]);
 
   return null; // No UI, just a service
 };

--- a/app/routes/_room.$roomName.room.tsx
+++ b/app/routes/_room.$roomName.room.tsx
@@ -211,7 +211,15 @@ function JoinedRoom({
 		return remoteTracks
 	}, [allRemoteAudioTrackIds, pulledAudioTracks, userMedia.audioStreamTrack])
 
-	const [showTranscription, setShowTranscription] = useState(false)
+       const [showTranscription, setShowTranscription] = useState(false)
+
+       const participantNames = useMemo(
+               () => [
+                       identity?.name,
+                       ...otherUsers.map((u) => u.name),
+               ].filter(Boolean) as string[],
+               [identity?.name, otherUsers]
+       )
 
 	return (
 		<PullAudioTracks
@@ -257,13 +265,14 @@ function JoinedRoom({
 			<HighPacketLossWarningsToast />
 			<IceDisconnectedToast />
 			{isTranscriptionHost && transcriptionEnabled && transcriptionProvider === 'openai' && hasOpenAiTranscription && (
-				<TranscriptionService
-					audioTracks={actualAudioTracks}
-					isActive={isTranscriptionHost}
-					onTranscription={(t) =>
-						setTranscriptions((prev) => [...prev, t])
-					}
-				/>
+                               <TranscriptionService
+                                       audioTracks={actualAudioTracks}
+                                       isActive={isTranscriptionHost}
+                                       participants={participantNames}
+                                       onTranscription={(t) =>
+                                               setTranscriptions((prev) => [...prev, t])
+                                       }
+                               />
 			)}
 			{transcriptionEnabled && (
 				<div className="fixed top-4 right-4 z-50 bg-white border border-gray-300 rounded-lg p-4 shadow-lg">

--- a/app/routes/api.transcription-token.tsx
+++ b/app/routes/api.transcription-token.tsx
@@ -30,7 +30,7 @@ export const action = async ({ context }: ActionFunctionArgs) => {
     // or use a different authentication method for better security
     return new Response(JSON.stringify({
       token: context.env.OPENAI_API_TOKEN,
-      model: 'whisper-1',
+      model: 'gpt-4o-transcribe',
       timestamp: Date.now()
     }), {
       status: 200,

--- a/app/routes/api.transcription-token.tsx
+++ b/app/routes/api.transcription-token.tsx
@@ -2,8 +2,12 @@ import type { ActionFunctionArgs } from '@remix-run/cloudflare'
 
 /**
  * API endpoint to provide OpenAI authentication token for real-time transcription
+ * 
+ * This endpoint returns the necessary authentication for both:
+ * 1. Real-time WebSocket API (gpt-4o-transcribe via WebSocket)
+ * 2. Standard transcription API (gpt-4o-transcribe via POST)
  */
-export const action = async ({ context }: ActionFunctionArgs) => {
+export const action = async ({ context, request }: ActionFunctionArgs) => {
   const corsHeaders = {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Methods': 'POST, OPTIONS',
@@ -25,12 +29,46 @@ export const action = async ({ context }: ActionFunctionArgs) => {
   }
 
   try {
-    // Return the OpenAI API token for client-side use
-    // Note: In production, you might want to create a time-limited token
-    // or use a different authentication method for better security
+    // Parse request body to check if ephemeral token is requested
+    let requestBody: any = {};
+    try {
+      requestBody = await request.json();
+    } catch {
+      // If no body or invalid JSON, continue with defaults
+    }
+
+    const isRealtimeRequest = requestBody.realtime === true;
+
+    // For real-time API, we could generate an ephemeral token here
+    // However, OpenAI's real-time API currently accepts the regular API key
+    // In the future, this could be enhanced to call OpenAI's ephemeral token endpoint
+    
+    if (isRealtimeRequest) {
+      // Future enhancement: Call OpenAI's ephemeral token endpoint
+      // const ephemeralToken = await generateEphemeralToken(context.env.OPENAI_API_TOKEN);
+      
+      return new Response(JSON.stringify({
+        token: context.env.OPENAI_API_TOKEN,
+        model: 'gpt-4o-transcribe',
+        type: 'realtime',
+        realtimeUrl: 'wss://api.openai.com/v1/realtime',
+        timestamp: Date.now(),
+        expiresIn: 3600 // 1 hour (for future ephemeral tokens)
+      }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          ...corsHeaders
+        }
+      })
+    }
+
+    // Standard transcription API token
     return new Response(JSON.stringify({
       token: context.env.OPENAI_API_TOKEN,
       model: 'gpt-4o-transcribe',
+      type: 'standard',
+      transcriptionUrl: 'https://api.openai.com/v1/audio/transcriptions',
       timestamp: Date.now()
     }), {
       status: 200,


### PR DESCRIPTION
## Summary
- connect to OpenAI realtime API with `gpt-4o-transcribe`
- fall back to POST API when websocket fails
- include meeting participants in transcription prompt
- expose new model in token endpoint

## Testing
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-organize-imports')*
- `npm run typecheck` *(fails: Cannot find type definition file for '@cloudflare/workers-types')*
- `npm run test` *(fails: vitest: not found)*